### PR TITLE
feat: Add bulk update for test executions by test cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ zephyr testexecution create \
   --test-cycle-key CPG-R1 \
   --status-name "Pass"
 
+# Update a single test execution
+zephyr testexecution update CPG-E1 --status-name "Pass"
+
+# Update all test executions in a test cycle
+zephyr testexecution update --test-cycle CPG-R1 --status-name "Pass"
+
 # Switch profile
 zephyr -p other-profile testcase list
 

--- a/src/commands/testexecution/options.ts
+++ b/src/commands/testexecution/options.ts
@@ -89,6 +89,7 @@ export function registerCreateOptions(command: Command): Command {
  * Type for 'testexecution update' options
  */
 export interface TestExecutionUpdateOptions {
+  testCycle?: string;
   statusName?: string;
   environmentName?: string;
   actualEndDate?: string;
@@ -103,6 +104,10 @@ export interface TestExecutionUpdateOptions {
  */
 export function registerUpdateOptions(command: Command): Command {
   command
+    .option(
+      "--test-cycle <key>",
+      "Update all test executions in the specified test cycle (e.g., CPG-R1)",
+    )
     .option("--status-name <name>", "Execution status (e.g., Pass, Fail, Not Executed)")
     .option("--environment-name <name>", "Environment name")
     .option(

--- a/src/commands/testexecution/update.ts
+++ b/src/commands/testexecution/update.ts
@@ -14,10 +14,23 @@ import { registerUpdateOptions, type TestExecutionUpdateOptions } from "./option
  * Register 'testexecution update' command
  */
 export function registerUpdateCommand(parent: Command): void {
-  const updateCommand = parent.command("update <idOrKey>").description("Update a test execution");
+  const updateCommand = parent
+    .command("update [idOrKey]")
+    .description("Update a test execution")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # Update a single test execution
+  zephyr testexecution update CP02-E1 --status-name "Pass"
+
+  # Update all test executions in a test cycle
+  zephyr testexecution update --test-cycle CP02-R1 --status-name "Pass"
+      `,
+    );
 
   registerUpdateOptions(updateCommand).action(
-    async (idOrKey: string, options: TestExecutionUpdateOptions, command) => {
+    async (idOrKey: string | undefined, options: TestExecutionUpdateOptions, command) => {
       try {
         // Get global options from parent command
         const globalOptions = command.parent?.parent?.opts() as GlobalOptions;
@@ -28,8 +41,6 @@ export function registerUpdateCommand(parent: Command): void {
         // Load configuration
         const config = loadConfig(globalOptions.config);
         const profile = getProfile(config, globalOptions.profile);
-
-        logger.info(`Updating test execution: ${idOrKey}`);
 
         // Create API client
         const client = createClient(profile);
@@ -55,14 +66,86 @@ export function registerUpdateCommand(parent: Command): void {
           process.exit(1);
         }
 
-        // Update test execution
-        await client.testexecutions.updateTestExecution(idOrKey, apiParams);
+        // Bulk update mode: update all executions in a test cycle
+        if (options.testCycle) {
+          if (idOrKey) {
+            logger.warn(
+              `Ignoring idOrKey "${idOrKey}" because --test-cycle option is specified`,
+            );
+          }
 
-        logger.info(`Test execution updated successfully`);
+          logger.info(`Updating all test executions in test cycle: ${options.testCycle}`);
 
-        // Fetch and return updated execution
-        const response = await client.testexecutions.getTestExecution(idOrKey);
-        console.log(JSON.stringify(response.data, null, 2));
+          // Fetch all test executions in the test cycle
+          const listParams = {
+            projectKey: profile.projectKey,
+            testCycle: options.testCycle,
+            maxResults: 1000,
+            startAt: 0,
+          };
+
+          const listResponse = await client.testexecutions.listTestExecutions(listParams);
+          const executions = listResponse.data.values || [];
+
+          if (executions.length === 0) {
+            logger.warn(`No test executions found in test cycle: ${options.testCycle}`);
+            process.exit(0);
+          }
+
+          logger.info(`Found ${executions.length} test execution(s) to update`);
+
+          // Update each execution
+          let successCount = 0;
+          let failCount = 0;
+          const results: Array<{ key: string; success: boolean; error?: string }> = [];
+
+          for (const execution of executions) {
+            const executionKey = execution.key || String(execution.id);
+            try {
+              await client.testexecutions.updateTestExecution(executionKey, apiParams);
+              logger.info(`Updated: ${executionKey}`);
+              successCount++;
+              results.push({ key: executionKey, success: true });
+            } catch (error) {
+              const errorMessage = formatError(error as Error);
+              logger.error(`Failed to update ${executionKey}: ${errorMessage}`);
+              failCount++;
+              results.push({ key: executionKey, success: false, error: errorMessage });
+            }
+          }
+
+          // Output summary
+          const summary = {
+            testCycle: options.testCycle,
+            total: executions.length,
+            success: successCount,
+            failed: failCount,
+            results,
+          };
+
+          console.log(JSON.stringify(summary, null, 2));
+
+          if (failCount > 0) {
+            process.exit(1);
+          }
+        } else {
+          // Single update mode: update a specific execution
+          if (!idOrKey) {
+            logger.error("Either idOrKey or --test-cycle option must be provided");
+            process.exit(1);
+          }
+
+          logger.info(`Updating test execution: ${idOrKey}`);
+
+          // Update test execution
+          await client.testexecutions.updateTestExecution(idOrKey, apiParams);
+
+          logger.info(`Test execution updated successfully`);
+
+          // Fetch and return updated execution
+          const response = await client.testexecutions.getTestExecution(idOrKey);
+          console.log(JSON.stringify(response.data, null, 2));
+        }
       } catch (error) {
         logger.error(formatError(error as Error));
         process.exit(1);


### PR DESCRIPTION
## Summary

This PR adds the ability to bulk update all test executions within a test cycle using the `--test-cycle` option in the `testexecution update` command.

## Problem

Currently, users can only update test executions one at a time by specifying an execution ID or key. When managing test cycles with many executions, this requires running the update command multiple times, which is time-consuming and error-prone.

## Solution

Added a `--test-cycle` option to the `testexecution update` command that allows updating all test executions in a specified test cycle at once.

## Changes

- Added `--test-cycle <key>` option to `testexecution update` command
- Implemented bulk update logic that fetches and updates all executions in a test cycle
- Provides detailed summary with success/failure counts
- Maintains full backward compatibility

## Usage Examples

```bash
# Update all executions in a test cycle
zephyr testexecution update --test-cycle CPG-R1 --status-name "Pass"
```

## Output

When using bulk update, the command outputs a JSON summary:
```json
{
  "testCycle": "CPG-R1",
  "total": 4,
  "success": 4,
  "failed": 0,
  "results": [
    { "key": "CPG-E1", "success": true },
    { "key": "CPG-E2", "success": true },
    { "key": "CPG-E3", "success": true },
    { "key": "CPG-E4", "success": true }
  ]
}
```

## Backward Compatibility

- ✅ Fully backward compatible
- ✅ Existing single execution update functionality remains unchanged
- ✅ `idOrKey` parameter is optional only when `--test-cycle` is provided

## Testing

- [x] Single execution update still works as before
- [x] Bulk update with valid test cycle
- [x] Error handling for empty/invalid test cycles
- [x] Partial failure handling

## Related

Addresses the need for bulk operations on test executions when managing test cycles.