### PR TITLE
fix: improve --step option for testcase create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ zephyr testcase get CPG-T1
 # Create test case
 zephyr testcase create --name "New Test Case"
 
-# Create with inline steps (use | to separate description and expected result)
+# Create with inline steps (use | to separate description, test data, and expected result)
 zephyr testcase create --name "Test" \
-  --step "Open the login page|Login page is displayed" \
-  --step "Enter credentials|Credentials are accepted" \
-  --step "Click submit button|User is logged in"
+  --step "Open the login page||Login page is displayed" \
+  --step "Enter credentials|user@example.com|Credentials are accepted" \
+  --step "Click submit button||User is logged in"
 
 # For test steps with custom fields, use the teststep command instead
 zephyr teststep create CPG-T1 \

--- a/src/commands/testcase/create.ts
+++ b/src/commands/testcase/create.ts
@@ -65,12 +65,13 @@ export function registerCreateCommand(parent: Command): void {
         const testSteps = options.step.map((step) => ({
           inline: {
             description: step.description,
+            ...(step.testData && { testData: step.testData }),
             ...(step.expectedResult && { expectedResult: step.expectedResult }),
           },
         }));
 
         await client.testcases.createTestCaseTestSteps(response.data.key, {
-          mode: "APPEND",
+          mode: "OVERWRITE",
           items: testSteps,
         });
 

--- a/src/commands/testcase/options.ts
+++ b/src/commands/testcase/options.ts
@@ -15,6 +15,7 @@ import {
  */
 export interface StepInput {
   description: string;
+  testData?: string;
   expectedResult?: string;
 }
 
@@ -81,14 +82,15 @@ export function registerCreateOptions(command: Command): Command {
     })
     .option(
       "--step <step>",
-      "Add inline test step: 'description' or 'description|expected result' (can be specified multiple times)",
+      "Add inline test step: 'description|test data|expected result' (can be specified multiple times)",
       (val, prev: StepInput[] = []) => {
         const parts = val.split("|");
         return [
           ...prev,
           {
             description: parts[0]?.trim() || "",
-            expectedResult: parts[1]?.trim(),
+            testData: parts[1]?.trim(),
+            expectedResult: parts[2]?.trim(),
           },
         ];
       },


### PR DESCRIPTION
## Summary
- Change test step creation mode from `APPEND` to `OVERWRITE`
- Add `testData` field support to `--step` option

## Changes
- Fix empty step being created when using `--step` option
- Support `description|testData|expectedResult` format for specifying test data

## Test plan
- [x] Verified `zephyr testcase create --name "Test" --step "desc||expected" --step "desc|data|expected"` works correctly
- [x] Confirmed no empty steps are created
- [x] Confirmed `testData` is correctly set