### PR TITLE
feat: add testcycle tree command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,75 @@ curl -L https://github.com/bun913/zephyr-cli/releases/latest/download/zephyr-lin
 chmod +x /usr/local/bin/zephyr
 ```
 
+## Highlights
+
+### Folder Tree View
+
+Get a tree view of all folders and test cases in your project. This is useful for understanding the structure of your test cases.
+
+> Note: This operation fetches data recursively and may take a long time for large projects.
+
+```bash
+# JSON output
+zephyr folder tree
+
+# Tree view (human-readable)
+zephyr --text folder tree
+```
+
+Output:
+```
+app1/ (30158975)
+├── CPG-T13: Test with steps
+├── ...
+├── general_user/ (30158978)
+│   ├── login/ (30158980)
+│   │   ├── validation/ (30158985)
+│   │   │   ├── CPG-T1: length
+│   │   │   └── ...
+│   │   └── office_select/ (30158984)
+│   └── user_profile/ (30158982)
+└── admin_user/ (30158979)
+```
+
+### Test Cycle Tree View
+
+Get a tree view of test cases in a specific test cycle, organized by folder structure.
+
+> Note: This operation fetches data recursively and may take a long time for large test cycles.
+
+```bash
+# JSON output
+zephyr testcycle tree CPG-R1
+
+# Tree view (human-readable)
+zephyr --text testcycle tree CPG-R1
+```
+
+Output:
+```
+app1/ (30158975)
+├── CPG-T13: Test with steps
+└── general_user/ (30158978)
+    ├── login/ (30158980)
+    │   └── validation/ (30158985)
+    │       └── CPG-T1: length
+    └── user_profile/ (30158982)
+        └── CPG-T5: change_icon
+(No Folder)/ (0)
+└── CPG-T23: Test
+```
+
 ## Commands
 
 | Command | Subcommands | Description |
 |---------|-------------|-------------|
 | `testcase` | list, get, create, update | Manage test cases |
-| `testcycle` | list, get, create, update | Manage test cycles |
+| `testcycle` | list, get, create, update, tree | Manage test cycles |
 | `testexecution` | list, get, create, update | Manage test executions |
 | `testplan` | list, get, create | Manage test plans |
 | `teststep` | list, create | Manage test steps |
-| `folder` | list, get, create | Manage folders |
+| `folder` | list, get, create, tree | Manage folders |
 | `environment` | list, get, create, update | Manage test environments |
 | `status` | list, get, create | Manage statuses |
 | `priority` | list, get, create | Manage priorities |

--- a/src/commands/testcycle/index.ts
+++ b/src/commands/testcycle/index.ts
@@ -6,6 +6,7 @@ import type { Command } from "commander";
 import { registerCreateCommand } from "./create";
 import { registerGetCommand } from "./get";
 import { registerListCommand } from "./list";
+import { registerTreeCommand } from "./tree";
 import { registerUpdateCommand } from "./update";
 
 /**
@@ -19,4 +20,5 @@ export function registerTestCycleCommand(program: Command): void {
   registerGetCommand(testcycle);
   registerCreateCommand(testcycle);
   registerUpdateCommand(testcycle);
+  registerTreeCommand(testcycle);
 }

--- a/src/commands/testcycle/tree.ts
+++ b/src/commands/testcycle/tree.ts
@@ -1,0 +1,242 @@
+/**
+ * Testcycle tree command implementation
+ */
+
+import type { Command } from "commander";
+import type { Folder, ZephyrClient } from "zephyr-api-client";
+import { getProfile, loadConfig } from "../../config/manager";
+import type { GlobalOptions } from "../../config/types";
+import { createClient } from "../../utils/client";
+import { formatError } from "../../utils/error";
+import { logger, setLoggerVerbose } from "../../utils/logger";
+import { type FolderTreeNode, printTreeAsText } from "../../utils/tree";
+
+/**
+ * Fetch all test executions for a test cycle
+ */
+async function fetchTestExecutions(
+  client: ZephyrClient,
+  projectKey: string,
+  testCycleKey: string,
+): Promise<{ testCaseKey: string }[]> {
+  const executions: { testCaseKey: string }[] = [];
+  let startAt = 0;
+  const maxResults = 100;
+
+  while (true) {
+    const response = await client.testexecutions.listTestExecutions({
+      projectKey,
+      testCycle: testCycleKey,
+      maxResults,
+      startAt,
+    });
+
+    const items = response.data.values || [];
+    for (const exec of items) {
+      // Extract test case key from self URL
+      const selfUrl = exec.testCase?.self;
+      if (selfUrl) {
+        const match = selfUrl.match(/testcases\/([^/]+)/);
+        if (match) {
+          executions.push({ testCaseKey: match[1] });
+        }
+      }
+    }
+
+    if (!response.data.next) {
+      break;
+    }
+    startAt += maxResults;
+  }
+
+  return executions;
+}
+
+/**
+ * Fetch test case details
+ */
+async function fetchTestCase(
+  client: ZephyrClient,
+  testCaseKey: string,
+): Promise<{ key: string; name: string; folderId: number | null }> {
+  const response = await client.testcases.getTestCase(testCaseKey);
+  const tc = response.data;
+  return {
+    key: tc.key,
+    name: tc.name,
+    folderId: tc.folder?.id ?? null,
+  };
+}
+
+/**
+ * Fetch folder details
+ */
+async function fetchFolder(client: ZephyrClient, folderId: number): Promise<Folder> {
+  const response = await client.folders.getFolder(folderId);
+  return response.data;
+}
+
+/**
+ * Build tree from test cases and folders
+ */
+function buildTree(
+  testCases: { key: string; name: string; folderId: number | null }[],
+  folders: Map<number, Folder>,
+): FolderTreeNode[] {
+  // Build adjacency list for folders
+  const adjacencyList = new Map<number | null, Folder[]>();
+  for (const folder of folders.values()) {
+    const parentId = folder.parentId ?? null;
+    if (!adjacencyList.has(parentId)) {
+      adjacencyList.set(parentId, []);
+    }
+    adjacencyList.get(parentId)?.push(folder);
+  }
+
+  // Group test cases by folder
+  const testCasesByFolder = new Map<number | null, { key: string; name: string }[]>();
+  for (const tc of testCases) {
+    const folderId = tc.folderId;
+    if (!testCasesByFolder.has(folderId)) {
+      testCasesByFolder.set(folderId, []);
+    }
+    testCasesByFolder.get(folderId)?.push({ key: tc.key, name: tc.name });
+  }
+
+  // DFS to build tree
+  function buildNode(folderId: number): FolderTreeNode {
+    const folder = folders.get(folderId);
+    if (!folder) {
+      throw new Error(`Folder ${folderId} not found`);
+    }
+
+    const children = adjacencyList.get(folderId) || [];
+    const childNodes: FolderTreeNode[] = [];
+    for (const child of children) {
+      childNodes.push(buildNode(child.id));
+    }
+
+    return {
+      id: folder.id,
+      name: folder.name,
+      children: childNodes,
+      testCases: testCasesByFolder.get(folderId) || [],
+    };
+  }
+
+  // Find root folders (folders with no parent in our set, or parent is null)
+  const rootFolderIds = new Set<number>();
+  for (const folder of folders.values()) {
+    if (folder.parentId === null || folder.parentId === undefined) {
+      rootFolderIds.add(folder.id);
+    } else if (!folders.has(folder.parentId)) {
+      rootFolderIds.add(folder.id);
+    }
+  }
+
+  const result: FolderTreeNode[] = [];
+  for (const rootId of rootFolderIds) {
+    result.push(buildNode(rootId));
+  }
+
+  // Add test cases without folder (at root level)
+  const rootTestCases = testCasesByFolder.get(null) || [];
+  if (rootTestCases.length > 0) {
+    result.push({
+      id: 0,
+      name: "(No Folder)",
+      children: [],
+      testCases: rootTestCases,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Register 'testcycle tree' command
+ */
+export function registerTreeCommand(parent: Command): void {
+  parent
+    .command("tree <testCycleKey>")
+    .description(
+      "Get folder tree with test cases for a test cycle (this operation may take a long time)",
+    )
+    .action(async (testCycleKey: string, _options, command) => {
+      try {
+        const globalOptions = command.parent?.parent?.opts() as GlobalOptions;
+        const useText = globalOptions.text || false;
+        setLoggerVerbose(globalOptions.verbose || false);
+
+        const config = loadConfig(globalOptions.config);
+        const profile = getProfile(config, globalOptions.profile);
+        const client = createClient(profile);
+
+        logger.info(`Fetching tree for test cycle: ${testCycleKey}`);
+        logger.info("This may take a while...");
+
+        // 1. Fetch all test executions
+        logger.info("Fetching test executions...");
+        const executions = await fetchTestExecutions(client, profile.projectKey, testCycleKey);
+        logger.info(`Found ${executions.length} test execution(s)`);
+
+        if (executions.length === 0) {
+          console.log(useText ? "(No test cases in this cycle)" : "[]");
+          return;
+        }
+
+        // 2. Fetch test case details (deduplicate keys)
+        const uniqueKeys = [...new Set(executions.map((e) => e.testCaseKey))];
+        logger.info(`Fetching ${uniqueKeys.length} test case(s)...`);
+
+        const testCases: { key: string; name: string; folderId: number | null }[] = [];
+        const folderIds = new Set<number>();
+
+        for (const key of uniqueKeys) {
+          logger.debug(`Fetching test case: ${key}`);
+          const tc = await fetchTestCase(client, key);
+          testCases.push(tc);
+          if (tc.folderId !== null) {
+            folderIds.add(tc.folderId);
+          }
+        }
+
+        // 3. Fetch folder details and their parents
+        logger.info("Fetching folder details...");
+        const folders = new Map<number, Folder>();
+        const foldersToFetch = [...folderIds];
+
+        while (foldersToFetch.length > 0) {
+          const folderId = foldersToFetch.pop();
+          if (folderId === undefined || folders.has(folderId)) {
+            continue;
+          }
+
+          logger.debug(`Fetching folder: ${folderId}`);
+          const folder = await fetchFolder(client, folderId);
+          folders.set(folderId, folder);
+
+          // Add parent to fetch queue
+          if (folder.parentId && !folders.has(folder.parentId)) {
+            foldersToFetch.push(folder.parentId);
+          }
+        }
+
+        logger.info(`Found ${folders.size} folder(s)`);
+
+        // 4. Build tree
+        logger.info("Building tree...");
+        const tree = buildTree(testCases, folders);
+
+        // 5. Output
+        if (useText) {
+          printTreeAsText(tree);
+        } else {
+          console.log(JSON.stringify(tree, null, 2));
+        }
+      } catch (error) {
+        logger.error(formatError(error as Error));
+        process.exit(1);
+      }
+    });
+}

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -1,0 +1,80 @@
+/**
+ * Common tree utilities for folder/testcycle tree commands
+ */
+
+/**
+ * Tree node structure for output
+ */
+export interface FolderTreeNode {
+  id: number;
+  name: string;
+  children: FolderTreeNode[];
+  testCases: { key: string; name: string }[];
+  hasMoreTestCases?: boolean;
+}
+
+/**
+ * Format tree as text output (recursive helper)
+ */
+export function formatTreeAsText(nodes: FolderTreeNode[], prefix = ""): string {
+  const lines: string[] = [];
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const isLast = i === nodes.length - 1;
+    const connector = isLast ? "└── " : "├── ";
+    const childPrefix = isLast ? "    " : "│   ";
+
+    lines.push(`${prefix}${connector}${node.name}/ (${node.id})`);
+
+    const hasMore = node.hasMoreTestCases ?? false;
+    const totalItems = node.children.length + node.testCases.length + (hasMore ? 1 : 0);
+    let itemIndex = 0;
+
+    for (const tc of node.testCases) {
+      itemIndex++;
+      const tcConnector = itemIndex === totalItems ? "└── " : "├── ";
+      lines.push(`${prefix}${childPrefix}${tcConnector}${tc.key}: ${tc.name}`);
+    }
+
+    if (hasMore) {
+      itemIndex++;
+      const moreConnector = itemIndex === totalItems ? "└── " : "├── ";
+      lines.push(`${prefix}${childPrefix}${moreConnector}...`);
+    }
+
+    if (node.children.length > 0) {
+      lines.push(formatTreeAsText(node.children, prefix + childPrefix));
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Print tree to console in text format
+ */
+export function printTreeAsText(tree: FolderTreeNode[]): void {
+  for (const root of tree) {
+    console.log(`${root.name}/ (${root.id})`);
+    const hasMore = root.hasMoreTestCases ?? false;
+    const totalItems = root.children.length + root.testCases.length + (hasMore ? 1 : 0);
+    let itemIndex = 0;
+
+    for (const tc of root.testCases) {
+      itemIndex++;
+      const connector = itemIndex === totalItems ? "└── " : "├── ";
+      console.log(`${connector}${tc.key}: ${tc.name}`);
+    }
+
+    if (hasMore) {
+      itemIndex++;
+      const connector = itemIndex === totalItems ? "└── " : "├── ";
+      console.log(`${connector}...`);
+    }
+
+    if (root.children.length > 0) {
+      console.log(formatTreeAsText(root.children));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `testcycle tree` command to view test cases in a test cycle organized by folder structure
- Refactor tree utilities into shared module

## Features

### testcycle tree
- Fetch all test executions in a test cycle
- Retrieve test case details and folder hierarchy
- Display as JSON or tree-view text format
- Test cases without folder are grouped under "(No Folder)"

### Refactoring
- Extract common tree utilities to `src/utils/tree.ts`
  - `FolderTreeNode` interface
  - `formatTreeAsText()` function
  - `printTreeAsText()` function

## Example
```bash
# JSON output
zephyr testcycle tree CPG-R1

# Tree view
zephyr --text testcycle tree CPG-R1
```

Output:
```
app1/ (30158975)
├── CPG-T13: Test with steps
└── general_user/ (30158978)
    └── login/ (30158980)
        └── validation/ (30158985)
            └── CPG-T1: length
(No Folder)/ (0)
└── CPG-T23: Test
```

## Test plan
- [x] Verified `zephyr testcycle tree CPG-R1` returns JSON
- [x] Verified `zephyr --text testcycle tree CPG-R1` returns tree view
- [x] Verified `folder tree` still works after refactoring
- [x] Updated README with Highlights section