### PR TITLE
fix: simplify folder tree to show only folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ chmod +x /usr/local/bin/zephyr
 
 ### Folder Tree View
 
-Get a tree view of all folders and test cases in your project. This is useful for understanding the structure of your test cases.
-
-> Note: This operation fetches data recursively and may take a long time for large projects.
+Get a tree view of all folders in your project. This is useful for understanding the folder structure.
 
 ```bash
 # JSON output
@@ -45,13 +43,9 @@ zephyr --text folder tree
 Output:
 ```
 app1/ (30158975)
-├── CPG-T13: Test with steps
-├── ...
 ├── general_user/ (30158978)
 │   ├── login/ (30158980)
 │   │   ├── validation/ (30158985)
-│   │   │   ├── CPG-T1: length
-│   │   │   └── ...
 │   │   └── office_select/ (30158984)
 │   └── user_profile/ (30158982)
 └── admin_user/ (30158979)

--- a/src/commands/folder/options.ts
+++ b/src/commands/folder/options.ts
@@ -76,36 +76,3 @@ export interface FolderCreateOptions {
   folderType: "TEST_CASE" | "TEST_PLAN" | "TEST_CYCLE";
   parentId?: number;
 }
-
-/**
- * Register options for 'folder tree' command
- */
-export function registerTreeOptions(command: Command): Command {
-  command
-    .option(
-      "--max-test-cases <number>",
-      "Maximum number of test cases per folder (default: 5, max: 50)",
-      (val) => {
-        const num = Number.parseInt(val, 10);
-        if (Number.isNaN(num) || num < 1) {
-          throw new Error("--max-test-cases must be a positive number");
-        }
-        if (num > 50) {
-          throw new Error("--max-test-cases cannot exceed 50");
-        }
-        return num;
-      },
-      5,
-    )
-    .option("--all", "Fetch all test cases (may take a long time)");
-
-  return command;
-}
-
-/**
- * Type for 'folder tree' options
- */
-export interface FolderTreeOptions {
-  maxTestCases: number;
-  all?: boolean;
-}


### PR DESCRIPTION
## Summary
- Simplify `folder tree` command to show only folder structure without test cases
- Significantly improves performance

## Changes
- Remove test case fetching from `folder tree` (was too slow)
- Remove `--max-test-cases` and `--all` options
- Update README

## Before
```
app1/ (30158975)
├── CPG-T13: Test with steps
├── ...
├── general_user/ (30158978)
```

## After
```
app1/ (30158975)
├── general_user/ (30158978)
│   ├── login/ (30158980)
│   └── user_profile/ (30158982)
└── admin_user/ (30158979)
```

## Test plan
- [x] Verified `zephyr --text folder tree` shows only folders
- [x] Verified performance is much faster